### PR TITLE
fix: add ctx handling that is recommended for sanic 19.0+ and required for sanic 20.0+

### DIFF
--- a/prometheus_sanic/handlers.py
+++ b/prometheus_sanic/handlers.py
@@ -6,21 +6,29 @@ from prometheus_sanic.constants import RequestMetaData, BaseMetrics
 
 
 def before_request_handler(request):
-    request[RequestMetaData.TIME] = time.time()
+    # Note, since sanic>=20.3.0 arbitrary setting request keys
+    # (e.g. request[...] = ...) are no longer supported. We need
+    # to use the ctx object which by default is SimpleNamespace
+    # instance. That's why we use setattr/getattr.
+    setattr(request.ctx, RequestMetaData.TIME, time.time())
 
     # Fetch handler from router
     try:
-        _handler, _args, _kwargs, uri = request.app.router.get(request)
-        request[RequestMetaData.ROUTER] = uri
+        # Note, number of elements in tuple returned from the
+        # request.app.router.get(request) is another backwards
+        # incompatible change that happened in sanic 20.3.0.
+        # To be more future-proof let's use *_ "rest unpacking"
+        _handler, _args, _kwargs, uri, *_ = request.app.router.get(request)
+        setattr(request.ctx, RequestMetaData.ROUTER, uri)
     except NotFound:
-        request[RequestMetaData.ROUTER] = None
+        setattr(request.ctx, RequestMetaData.ROUTER, None)
     except InvalidUsage:
-        request[RequestMetaData.ROUTER] = None
+        setattr(request.ctx, RequestMetaData.ROUTER, None)
 
 
 def after_request_endpoint_handler(request, response, get_endpoint_fn,
                                    *args, **kwargs):
-    lat = time.time() - request[RequestMetaData.TIME]
+    lat = time.time() - getattr(request.ctx, RequestMetaData.TIME)
     endpoint = get_endpoint_fn(request)
 
     # Note, that some handlers can ignore response logic,
@@ -35,9 +43,8 @@ def after_request_endpoint_handler(request, response, get_endpoint_fn,
 
 
 def after_request_uri_handler(request, response, *args, **kwargs):
-    lat = time.time() - request[RequestMetaData.TIME]
-
-    uri = request[RequestMetaData.ROUTER]
+    lat = time.time() - getattr(request.ctx, RequestMetaData.TIME)
+    uri = getattr(request.ctx, RequestMetaData.ROUTER)
 
     # Note, that some handlers can ignore response logic,
     # for example, websocket handler


### PR DESCRIPTION
Sanic 20.3.0 broke backwards compatibility of few things. Unfortunately, at the time of writing this PR the upstream repository still lacks proper changelog (see huge-success/sanic/issues/1854). It means I can't tell if there are no other broken things without reading through all diffs.

Main problems were:
- setting custom request attributes via `request[...] = ...` is no longer possible
- different number of `request.app.router.get(request)` return tuple elements

This PR fixes that issue by storing URI and TIME attributes in `request.ctx` SimpleNamespace container that should be available since sanic 19.0.0. It means newer version will work only with sanic 19.0.0+. From README I inferred that there is no compat layer intended for older versions (e.g. simple version checcking) so I didn't add any.
